### PR TITLE
Support only RefinedTypeThrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # unreleased
 
+### :warning: Breaking changes
+
+- offer implicit circe decoders only for `RefinedTypeThrow[O, N]` instead of `RefinedType[O, N, E]`. This is part of a larger decision that pureharm simply uses Throwable subtypes for errors. The support for the generic version also tripped up end users that didn't have a `Show[Throwable]` instance in scope.
+
 ### Deprecations
 
 - all `unsafe` syntax extensions are now deprecated. Will be removed in `0.3.0`. Just throw exceptions in the few places in client code where necessary.

--- a/json-circe/shared/src/main/scala/busymachines/pureharm/internals/json/PureharmJsonInstances.scala
+++ b/json-circe/shared/src/main/scala/busymachines/pureharm/internals/json/PureharmJsonInstances.scala
@@ -16,9 +16,6 @@
 
 package busymachines.pureharm.internals.json
 
-import scala.annotation.implicitNotFound
-
-import cats._
 import cats.implicits._
 import busymachines.pureharm.sprout._
 import io.circe.{Decoder, Encoder}
@@ -40,14 +37,10 @@ object PureharmJsonInstances {
       decoder: Decoder[Old],
     ): Decoder[New] = decoder.map(newType.newType)
 
-    implicit final def pureharmSproutRefinedCirceDecoder[Old, New, E](implicit
-      newType: RefinedType[Old, New, E],
+    implicit final def pureharmSproutRefinedCirceDecoder[Old, New](implicit
+      newType: RefinedTypeThrow[Old, New],
       decoder: Decoder[Old],
-      @implicitNotFound(
-        """Deriving a io.circe.Decoder[${Phantom}] for refined sprout types, requires you to have a Show[${E}] in scope. If your error is of type Throwable, then pureharm.effects.implicits._ contains a Show instance for it. If you used pureharm style, then myapp.effects._ package should have one"""
-      )
-      show:    Show[E],
-    ): Decoder[New] = decoder.emap(u => newType.newType[Either[E, *]](u).leftMap(_.show))
+    ): Decoder[New] = decoder.emap(u => newType.newType[Either[Throwable, *]](u).leftMap(_.toString()))
 
   }
 

--- a/json-circe/shared/src/test/scala/busymachines/pureharm/json/test/derivetest/semiAutoMelonJsonCodec.scala
+++ b/json-circe/shared/src/test/scala/busymachines/pureharm/json/test/derivetest/semiAutoMelonJsonCodec.scala
@@ -19,7 +19,6 @@ package busymachines.pureharm.json.test.derivetest
 import busymachines.pureharm.json._
 import busymachines.pureharm.json.implicits._
 import busymachines.pureharm.json.test._
-import busymachines.pureharm.anomaly._
 
 /** @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 11 Jun 2019


### PR DESCRIPTION
Pureharm encourages just using Throwable subtypes for errors. This constraint trips up users in auto derivation